### PR TITLE
Support of langage diversity for more control on surfaces generated

### DIFF
--- a/levels/instr_gen.py
+++ b/levels/instr_gen.py
@@ -183,13 +183,13 @@ def gen_locrel(obj=None, act=None, constraints=set()):
 def gen_state(obj=None, act=None, constraints=set()):
     return gen_subattr('state', constraints|(set() if not obj else {obj}))
 
-def choice(elems, diversity=None):
-    print(diversity)
-    if diversity != None:
-        elems = elems[:diversity]
+def choice(elems, lang_variation=None):
+    print(lang_variation)
+    if lang_variation != None:
+        elems = elems[:lang_variation]
     return random.choice(elems)
 
-def gen_surface(ntup, seed=0, conditions={}, diversity=None):
+def gen_surface(ntup, seed=0, conditions={}, lang_variation=None):
     if ntup == None:
         return ''
 
@@ -198,14 +198,14 @@ def gen_surface(ntup, seed=0, conditions={}, diversity=None):
         s_instr = ''
         for i, ainstr in enumerate(ntup):
             if i > 0:
-                s_instr += choice([' and then', ', then'], diversity) + ' '
-            s_instr += gen_surface(ainstr, diversity=diversity)
+                s_instr += choice([' and then', ', then'], lang_variation) + ' '
+            s_instr += gen_surface(ainstr, lang_variation=lang_variation)
         return s_instr
 
     if isinstance(ntup, Instr):
-        s_ainstr = gen_surface(ntup.action, diversity=diversity)
+        s_ainstr = gen_surface(ntup.action, lang_variation=lang_variation)
         if ntup.action != 'drop':
-            s_ainstr += ' ' + gen_surface(ntup.object, diversity=diversity)
+            s_ainstr += ' ' + gen_surface(ntup.object, lang_variation=lang_variation)
         return s_ainstr
 
     if isinstance(ntup, Object):
@@ -215,40 +215,40 @@ def gen_surface(ntup, seed=0, conditions={}, diversity=None):
         for f in s_attrs:
             if not f:
                 continue
-            cond = choice(['pre', 'after', 'which is', 'that is'], diversity)
+            cond = choice(['pre', 'after', 'which is', 'that is'], lang_variation)
             if cond == 'pre':
-                s_obj = gen_surface(f, conditions={cond}, diversity=diversity) + ' ' + s_obj
+                s_obj = gen_surface(f, conditions={cond}, lang_variation=lang_variation) + ' ' + s_obj
             if cond == 'after':
                 if 'which is' in s_obj or 'that is' in s_obj:
-                    s_obj = s_obj + ' and is ' + gen_surface(f, conditions={cond}, diversity=diversity)
+                    s_obj = s_obj + ' and is ' + gen_surface(f, conditions={cond}, lang_variation=lang_variation)
                 else:
-                    s_obj = s_obj + ' ' + (('which is ' + gen_surface(f, conditions={cond}, diversity=diversity)) if f in CONCEPTS['state'] else gen_surface(f, conditions={cond}, diversity=diversity))
+                    s_obj = s_obj + ' ' + (('which is ' + gen_surface(f, conditions={cond}, lang_variation=lang_variation)) if f in CONCEPTS['state'] else gen_surface(f, conditions={cond}, lang_variation=lang_variation))
             if cond in ['which is', 'that is']:
                 if 'which is' in s_obj or 'that is' in s_obj:
-                    s_obj = s_obj + ' and is ' + gen_surface(f, conditions={cond}, diversity=diversity)
+                    s_obj = s_obj + ' and is ' + gen_surface(f, conditions={cond}, lang_variation=lang_variation)
                 else:
-                    s_obj = s_obj + ' {} '.format(cond) + gen_surface(f, conditions={cond}, diversity=diversity)
+                    s_obj = s_obj + ' {} '.format(cond) + gen_surface(f, conditions={cond}, lang_variation=lang_variation)
         return 'the '+ s_obj
 
     if ntup == 'goto':
-        return choice(['go to', 'reach', 'find', 'walk to'], diversity)
+        return choice(['go to', 'reach', 'find', 'walk to'], lang_variation)
 
     if ntup == 'pickup':
         return choice(
             ['pickup', 'pick up', 'grasp', 'go pick', 'go grasp', 'go get', 'get', 'go fetch', 'fetch'],
-            diversity)
+            lang_variation)
 
     if ntup == 'drop':
-        return choice(['drop', 'drop down', 'put down'], diversity)
+        return choice(['drop', 'drop down', 'put down'], lang_variation)
 
     if ntup == 'open':
-        return choice(['open'], diversity)
+        return choice(['open'], lang_variation)
 
     if ntup in CONCEPTS['color']:
         if {'pre'} & conditions:
             return ntup
         if {'after'} & conditions:
-            return choice(['in {}'.format(ntup)], diversity) #'with the color of {}'.format(ntup), 
+            return choice(['in {}'.format(ntup)], lang_variation) #'with the color of {}'.format(ntup), 
         if {'which is', 'that is'} & conditions:
             return ntup 
 
@@ -256,16 +256,16 @@ def gen_surface(ntup, seed=0, conditions={}, diversity=None):
         if {'pre'} & conditions:
             return ntup
         if {'after', 'which is', 'that is'} & conditions:
-            return choice(['on the {}'.format(ntup), 'on the {} direction'.format(ntup)], diversity)
+            return choice(['on the {}'.format(ntup), 'on the {} direction'.format(ntup)], lang_variation)
 
     if ntup in CONCEPTS['loc_rel']:
         if {'pre'} & conditions:
             return ntup
         if {'which is', 'that is', 'after'} & conditions:
-            return choice(['on your {}'.format(ntup)], diversity)
+            return choice(['on your {}'.format(ntup)], lang_variation)
 
     if ntup in CONCEPTS['state']:
-        return choice([ntup], diversity)
+        return choice([ntup], lang_variation)
 
 def test():
     for i in range(10):

--- a/levels/levels.py
+++ b/levels/levels.py
@@ -15,16 +15,16 @@ class Mission(gym.Wrapper):
     Wrapper for missions, usable as a gym environment.
     """
 
-    def __init__(self, seed, instrs, env, diversity=None):
+    def __init__(self, seed, instrs, surface, env):
         self.seed = seed
 
         self.instrs = instrs
 
+        self.surface = surface
+
         # Keep a copy of the original environment so we can reset it
         self.orig_env = env
         self.env = deepcopy(self.orig_env)
-
-        self.diversity = diversity
 
         self.actions = env.actions
 
@@ -46,11 +46,6 @@ class Mission(gym.Wrapper):
         reward = 1 if done else 0
 
         return obs, reward, done, info
-
-    @property
-    def surface(self):
-        """Produce an English string for the instructions"""
-        return gen_surface(self.instrs, seed=self.seed, diversity=self.diversity)
 
 class Level:
     """
@@ -85,8 +80,9 @@ class Level0(Level):
 
     def _gen_mission(self, seed, rng):
         instrs = [Instr(action="goto", object=Object(type="door", color="red", loc=None, state=None))]
+        surface = gen_surface(instrs, seed, lang_variation=1)
         env = gen_env(instrs, seed, max_steps=50)
-        return Mission(seed, instrs, env)
+        return Mission(seed, instrs, surface, env)
 
 class Level1(Level):
     """
@@ -101,8 +97,9 @@ class Level1(Level):
         state = rng.choice(['locked', None])
         object = Object(type="door", color=color, loc=None, state=state)
         instrs = [Instr(action="goto", object=object)]
+        surface = gen_surface(instrs, seed, lang_variation=1)
         env = gen_env(instrs, seed, max_steps=50)
-        return Mission(seed, instrs, env)
+        return Mission(seed, instrs, surface, env)
 
 class Level2(Level):
     """
@@ -116,8 +113,9 @@ class Level2(Level):
         color = rng.choice(COLOR_NAMES)
         type = rng.choice(['door', 'ball', 'key', 'box'])
         instrs = [Instr(action="goto", object=Object(type=type, color=color, loc=None, state=None))]
+        surface = gen_surface(instrs, seed, lang_variation=2)
         env = gen_env(instrs, seed, max_steps=50, distractors=True)
-        return Mission(seed, instrs, env)
+        return Mission(seed, instrs, surface, env)
 
 class Level3(Level):
     """
@@ -140,6 +138,7 @@ class Level3(Level):
         color = rng.choice(COLOR_NAMES)
         object = Object(type=type, color=color, loc=None, state=None)
         instrs = [Instr(action=action, object=object)]
+        surface = gen_surface(instrs, seed)
 
         env = gen_env(
             instrs,
@@ -148,7 +147,7 @@ class Level3(Level):
             distractors=True
         )
 
-        return Mission(seed, instrs, env)
+        return Mission(seed, instrs, surface, env)
 
 class Level4(Level):
     """
@@ -164,6 +163,7 @@ class Level4(Level):
             Instr(action="pickup", object=Object(type='key', color=color, loc=None, state=None)),
             Instr(action="open", object=Object(type='door', color=color, loc=None, state='locked'))
         ]
+        surface = gen_surface(instrs, seed)
 
         env = gen_env(
             instrs,
@@ -172,7 +172,7 @@ class Level4(Level):
             distractors=True
         )
 
-        return Mission(seed, instrs, env)
+        return Mission(seed, instrs, surface, env)
 
 class Level5(Level):
     """
@@ -194,8 +194,9 @@ class Level5(Level):
 
         object = Object(type=type, color=color, loc=loc, state=None)
         instrs = [Instr(action="pickup", object=object)]
+        surface = gen_surface(instrs, seed)
         env = gen_env(instrs, seed, max_steps=50, distractors=True)
-        return Mission(seed, instrs, env)
+        return Mission(seed, instrs, surface, env)
 
 # Level list, indexable by level number
 # ie: level_list[0] is a Level0 instance

--- a/levels/levels.py
+++ b/levels/levels.py
@@ -15,7 +15,7 @@ class Mission(gym.Wrapper):
     Wrapper for missions, usable as a gym environment.
     """
 
-    def __init__(self, seed, instrs, env):
+    def __init__(self, seed, instrs, env, diversity=None):
         self.seed = seed
 
         self.instrs = instrs
@@ -23,6 +23,8 @@ class Mission(gym.Wrapper):
         # Keep a copy of the original environment so we can reset it
         self.orig_env = env
         self.env = deepcopy(self.orig_env)
+
+        self.diversity = diversity
 
         self.actions = env.actions
 
@@ -48,7 +50,7 @@ class Mission(gym.Wrapper):
     @property
     def surface(self):
         """Produce an English string for the instructions"""
-        return gen_surface(self.instrs, seed=self.seed)
+        return gen_surface(self.instrs, seed=self.seed, diversity=self.diversity)
 
 class Level:
     """


### PR DESCRIPTION
Additional optional `diversity` parameter for the `gen_surface` function. When `diversity` is `None`, no control on language diversity. If `diversity` is an integer `n`, all the choices are restricted to `n` options.